### PR TITLE
Use cookie instead of credentials for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,28 @@
 A command line utility to export and import your ratings.
 
 ## Usage
+To do its task, this tool needs to make Netflix believe that it is you. Sadly, this can no longer be done
+with just your username and password. Instead, you will have to extract the cookie Netflix sets for you
+and provide it to the CLI. But don't worry, I'll guide you through the entire process.
 
-First, you will need to retrieve the cookie Netflix sets in your browser after you log in. To do that, please log into
-your account just as usual. Once you're logged in, please open your browser's developer tools by pressing F12. Please
-make sure you are in the console tab of the dev tools. You should now have an input field, where you need to
-enter `document.cookie` and press enter. Please copy the value that is returned by your browsers (including the
-quotation marks!). This value will be required in a moment.
+### Extracting the cookie
+First, you'll need to login to Netflix and select your profile, just as usual. Now, please open your
+browser's dev tools by pressing F12 or right-clicking on the website and choosing "Inspect". Please
+select the "Network" tab on the top of the window that just popped up.
 
-Next, you can execute the actual commands. Please replace the actual values by your own:
+You should see a list of requests that Netflix is making. Scroll to the very top, where you should find
+a request to `www.netflix.com`. If you don't see this request, just reload the page while the network tab
+is open and look for it, again.
+
+Next, please click on this request. A new area should appear with a tab named "Headers". In that tab, please
+scroll down to the area titled "Request Headers" and search for `cookie: [very long value]`. Please copy
+this entire value. Make sure you do not miss any characters.
+
+### Passing the cookie to the CLI
+Now that you've got your cookie, you can execute the actual commands. Please replace the actual values
+below with your own. Make sure the cookie is surrounded by quotation marks! That section of the command
+should look somewhat like `--cookie "memclid=...%7D"` (your value inside the quotation marks might vary!).
+Here are the commands you'll need:
 
 ```
 npx netflix-migrate --cookie "your=cookie from=just-now" --profile Lana --export netflixData.json

--- a/README.md
+++ b/README.md
@@ -3,14 +3,31 @@
 A command line utility to export and import your ratings.
 
 ## Usage
-```
-npx netflix-migrate --email old@example.com --profile Lana --export netflixData.json
-npx netflix-migrate --email new@example.com --profile Lana --import netflixData.json
-```
-You will be prompted for your email address, password, and/or profile name if not provided as a parameter. If you do not specify a file path for `--export` or `--import`, `stdout` and `stdin` will be used, respectively. If `--export` or `--import` are not provided, `--export` is assumed (and `stdout` will be used).
 
-Your exported data will also contain your viewing history. Currently, the import function is only able to import the rating history, but that will hopefully change soon. However, you now already have your data and once the functionality is added you will be able to import your old viewing history too, even if you don't have any access to the old account anymore.
+First, you will need to retrieve the cookie Netflix sets in your browser after you log in. To do that, please log into
+your account just as usual. Once you're logged in, please open your browser's developer tools by pressing F12. Please
+make sure you are in the console tab of the dev tools. You should now have an input field, where you need to
+enter `document.cookie` and press enter. Please copy the value that is returned by your browsers (including the
+quotation marks!). This value will be required in a moment.
+
+Next, you can execute the actual commands. Please replace the actual values by your own:
+
+```
+npx netflix-migrate --cookie "your=cookie from=just-now" --profile Lana --export netflixData.json
+npx netflix-migrate --cookie "your=cookie from=just-now" --profile Lana --import netflixData.json
+```
+
+You will be prompted for your cookie, and/or profile name if not provided as a parameter. In this case, please make sure
+you don't wrap the value by quotation marks! If you do not specify a file path for `--export` or `--import`,
+`stdout` and `stdin` will be used, respectively. If `--export` or `--import` are not provided, `--export` is assumed (
+and `stdout` will be used).
+
+Your exported data will also contain your viewing history. Currently, the import function is only able to import the
+rating history, but that will hopefully change soon. However, you now already have your data and once the functionality
+is added you will be able to import your old viewing history too, even if you don't have any access to the old account
+anymore.
 
 ## Warning
 
-Use of this software may constitute a breach in the [Netflix Terms of Use](https://help.netflix.com/legal/termsofuse) and/or the [End User License Agreement](https://help.netflix.com/legal/eula). Use at your own risk.
+Use of this software may constitute a breach in the [Netflix Terms of Use](https://help.netflix.com/legal/termsofuse)
+and/or the [End User License Agreement](https://help.netflix.com/legal/eula). Use at your own risk.

--- a/index.js
+++ b/index.js
@@ -5,10 +5,14 @@ const program = require('commander');
 const prompt = require('prompt');
 const main = require('./main');
 
+const cookieHelpInstructions = 'You must provide the cookie that Netflix sets in your browser after you log in. To do this, please' +
+  ' log in manually, then press F12 and make sure you open a tab called "Console". In its input field, please' +
+  ' enter "document.cookie" and hit enter. The value you receive then is what you should provide as this parameter.' +
+  ' Make sure to wrap it in double quotes (i.e. --cookie "[cookie value]")!'
+
 // Specify supported arguments
 program
-  .option('-e, --email <email>')
-  .option('-p, --password <password>')
+  .option('-c, --cookie <cookie>', cookieHelpInstructions)
   .option('-r, --profile <profile>')
   .option('-i, --import [file]')
   .option('-x, --export [file]')
@@ -33,16 +37,12 @@ prompt.message = '';
 prompt.colors = false;
 
 // Specify values the user should be prompted for
-var prompts = [{
-  name: 'email',
-  description: 'Email'
-}, {
-  name: 'password',
-  description: 'Password',
-  hidden: true
+const prompts = [{
+  name: 'cookie',
+  description: cookieHelpInstructions
 }, {
   name: 'profile',
-  description: 'Profile'
+  description: 'Profile name. Please pay special attention to spelling!'
 }];
 
 // Prompt user for remaining values and pass them on to main

--- a/main.js
+++ b/main.js
@@ -20,9 +20,10 @@ const sleep = util.promisify(setTimeout);
 async function main(args, netflix = new Netflix()) {
 	try {
 		console.log('Logging into Netflix using Cookies');
+		const cookies = args.cookie && args.cookie.split(/\r?\n/gm).join('').trim()
 		await netflix.login({
 								// remove linie breaks, just in case
-								cookies: args.cookie && args.cookie.split(/\r?\n/gm).join('')
+								cookies: cookies
 							});
 
 		console.log('Switching to profile ' + args.profile);

--- a/main.test.js
+++ b/main.test.js
@@ -14,45 +14,45 @@ const fs = require('fs');
 
 describe('exitWithMessage', () => {
 	let processExit, consoleError;
-	
+
 	beforeEach(() => {
 		processExit = sinon.stub(process, 'exit');
 		consoleError = sinon.stub(console, 'error');
 	});
-	
+
 	afterEach(() => {
 		processExit.restore();
 		consoleError.restore();
 	});
-	
+
 	it('Should should print the provided error to the console via console.error', () => {
 		const message = 'bla bla';
 		exitWithMessage(message);
-		
+
 		expect(consoleError).to.have.been.calledOnceWithExactly(message);
 	});
-	
+
 	it('Should should exit the process with exit code 1', () => {
 		const message = 'bla bla';
 		exitWithMessage(message);
-		
+
 		expect(processExit).to.have.been.calledOnceWithExactly(1);
 	});
-	
+
 	it('Should should exit the process after printing the message to the console', () => {
 		const message = 'bla bla';
 		exitWithMessage(message);
-		
+
 		expect(processExit).to.have.been.calledImmediatelyAfter(consoleError);
 	});
 });
 
 describe('waterfall', () => {
 	let promises = [];
-	
+
 	beforeEach(() => {
 		promises = [];
-		
+
 		for (let i = 0; i < 10; i++) {
 			promises.push(
 				sinon
@@ -63,18 +63,18 @@ describe('waterfall', () => {
 			);
 		}
 	});
-	
+
 	it('Should return a promise', () => {
 		expect(waterfall([])).to.be.instanceOf(Promise);
 	});
-	
+
 	it('Should execute all promises', async () => {
 		await waterfall(promises);
 		for (const promise of promises) {
 			expect(promise).to.have.been.calledOnce;
 		}
 	});
-	
+
 	it('Should execute all promises in correct order', async () => {
 		await waterfall(promises);
 		for (let i = 1; i < promises.length; i++) {
@@ -98,59 +98,59 @@ describe('getProfileGuid', () => {
 		{firstName: '1234567890', guid: '8'},
 		{firstName: 'What\'s wrong with you?', guid: '9'}
 	];
-	
+
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixGetProfiles = sinon.stub(netflix, 'getProfiles')
 			.resolves([{firstName: ''}]);
 		consoleError = sinon.stub(console, 'error');
 	});
-	
+
 	afterEach(() => {
 		netflixGetProfiles.restore();
 		consoleError.restore();
 	});
-	
+
 	it('Should return a Promise', () => {
 		expect(getProfileGuid(netflix, '')).to.be.instanceOf(Promise);
 	});
-	
+
 	it('Should resolve promise with correct profile guid', async () => {
 		netflixGetProfiles.resolves(profiles);
-		
+
 		for (const profile of profiles) {
 			const result = getProfileGuid(netflix, profile.firstName);
-			
+
 			await expect(result).to.eventually.be.fulfilled;
 			await expect(result).to.eventually.become(profile.guid);
 		}
 	});
-	
+
 	it('Should reject promise when no matching profile is found', async () => {
 		netflixGetProfiles.resolves(profiles);
-		
+
 		const result = getProfileGuid(netflix, 'Non-existent name');
-		
+
 		await expect(result).to.eventually.be.rejected;
 	});
-	
+
 	it('Should log any error thrown by netflix.getProfiles', async () => {
 		const error = new Error('Error thrown by test');
 		netflixGetProfiles.rejects(error);
-		
+
 		try {
 			await getProfileGuid(netflix, '');
 		} catch (e) {
-		
+
 		} finally {
 			expect(consoleError).to.have.been.calledOnce;
 			expect(consoleError).to.have.been.calledWithExactly(error);
 		}
 	});
-	
+
 	it('Should throw an error when netflix.getProfiles throws an error', async () => {
 		netflixGetProfiles.rejects(new Error());
-		
+
 		await expect(getProfileGuid(netflix, '')).to.eventually.be.rejected;
 	});
 });
@@ -159,53 +159,53 @@ describe('switchProfile', () => {
 	let netflix, netflixSwitchProfile, consoleError;
 	const guid = {foo: 'bar'};
 	const result = {so: 'amazing'};
-	
+
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixSwitchProfile = sinon.stub(netflix, 'switchProfile')
 			.resolves(result);
 		consoleError = sinon.stub(console, 'error');
 	});
-	
+
 	afterEach(() => {
 		netflixSwitchProfile.restore();
 		consoleError.restore();
 	});
-	
+
 	it('Should return a promise', () => {
 		expect(switchProfile(netflix, guid)).to.be.instanceOf(Promise);
 	});
-	
+
 	it('Should call netflix.switchProfile and return it\'s value', async () => {
 		const res = await switchProfile(netflix, guid);
 		expect(netflixSwitchProfile).to.have.been.calledWithExactly(guid);
 		expect(res).to.deep.equal(result);
 	});
-	
+
 	it('Should log any error thrown by netflix.switchProfile', async () => {
 		const error = new Error('Error thrown by test');
 		netflixSwitchProfile.rejects(error);
-		
+
 		try {
 			await switchProfile(netflix, guid);
 		} catch (e) {
-		
+
 		} finally {
 			expect(consoleError).to.have.been.calledOnce;
 			expect(consoleError).to.have.been.calledWithExactly(error);
 		}
 	});
-	
+
 	it('Should throw an error when netflix.switchProfile throws an error', async () => {
 		netflixSwitchProfile.rejects(new Error());
-		
+
 		await expect(switchProfile(netflix, guid)).to.eventually.be.rejected;
 	});
 });
 
 describe('writeToChosenOutput', () => {
 	let fsWriteFileSync, processStdoutWrite, jsonStringify;
-	
+
 	const data = [
 		{
 			'ratingType': 'star',
@@ -264,7 +264,7 @@ describe('writeToChosenOutput', () => {
 		expect(processStdoutWrite).to.have.been.calledOnce;
 		expect(fsWriteFileSync).to.not.have.been.called;
 	});
-	
+
 	it('Should only print to file when filename is specified', async () => {
 		writeToChosenOutput(data, filename);
 		expect(fsWriteFileSync).to.have.been.calledOnce;
@@ -272,22 +272,22 @@ describe('writeToChosenOutput', () => {
 		expect(processStdoutWrite).to.have.been.calledOnce;
 		expect(processStdoutWrite).to.have.been.calledWith('Writing results to ' + filename + '\n');
 	});
-	
+
 	it('Should print correct JSON to process.stdout', async () => {
 		writeToChosenOutput(data, undefined, null);
 		expect(processStdoutWrite).to.have.been.calledWithExactly(dataJSON);
 	});
-	
+
 	it('Should print correct JSON to file', async () => {
 		writeToChosenOutput(data, filename, null);
 		expect(fsWriteFileSync).to.have.been.calledOnceWith(filename, dataJSON);
 	});
-	
+
 	it('Should print correct JSON when spaces is set to 4', async () => {
 		writeToChosenOutput(data, filename, 4);
 		expect(fsWriteFileSync).to.have.been.calledOnceWith(filename, dataJSONWith4Spaces);
 	});
-	
+
 	it('Should print correct JSON when spaces is set to 3', async () => {
 		writeToChosenOutput(data, filename, 3);
 		expect(fsWriteFileSync).to.have.been.calledOnceWith(filename, dataJSONWith3Spaces);
@@ -317,51 +317,51 @@ describe('getRatingHistory', () => {
 			'comparableDate': 2234567890
 		}
 	];
-	
+
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixGetRatingHistory = sinon.stub(netflix, 'getRatingHistory')
 			.resolves(ratings);
 		consoleError = sinon.stub(console, 'error');
 	});
-	
+
 	afterEach(() => {
 		netflixGetRatingHistory.restore();
 		consoleError.restore();
 	});
-	
+
 	it('Should return a promise', () => {
 		expect(getRatingHistory(netflix)).to.be.instanceOf(Promise);
 	});
-	
+
 	it('Should call netflix.getRatingsHistory()', async () => {
 		await getRatingHistory(netflix);
-		
+
 		expect(netflixGetRatingHistory).to.have.been.calledOnce;
 		expect(netflixGetRatingHistory).to.have.been.calledWithExactly();
 	});
-	
+
 	it('Should resolve with the result of netflix.getRatingHistory', async () => {
 		await expect(getRatingHistory(netflix)).to.eventually.deep.equal(ratings);
 	});
-	
+
 	it('Should log any error thrown by netflix.getRatingHistory', async () => {
 		const error = new Error('Error thrown by test');
 		netflixGetRatingHistory.rejects(error);
-		
+
 		try {
 			await getRatingHistory(netflix);
 		} catch (e) {
-		
+
 		} finally {
 			expect(consoleError).to.have.been.calledOnce;
 			expect(consoleError).to.have.been.calledWithExactly(error);
 		}
 	});
-	
+
 	it('Should throw an error when netflix.getRatingHistory throws an error', async () => {
 		netflixGetRatingHistory.rejects(new Error());
-		
+
 		await expect(getRatingHistory(netflix)).to.eventually.be.rejected;
 	});
 });
@@ -389,19 +389,19 @@ describe('getViewingHistory', () => {
 			'comparableDate': 2234567890
 		}
 	];
-	
+
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixGetViewingHistory = sinon.stub(netflix, 'getViewingHistory')
 			.resolves(viewingHistory);
 		consoleError = sinon.stub(console, 'error');
 	});
-	
+
 	afterEach(() => {
 		netflixGetViewingHistory.restore();
 		consoleError.restore();
 	});
-	
+
 	it('Should return a promise', () => {
 		expect(getViewingHistory(netflix)).to.be.instanceOf(Promise);
 	});
@@ -416,31 +416,31 @@ describe('getViewingHistory', () => {
 	it('Should resolve with the result of netflix.getViewingHistory', async () => {
 		await expect(getViewingHistory(netflix)).to.eventually.deep.equal(viewingHistory);
 	});
-	
+
 	it('Should log any error thrown by netflix.getViewingHistory', async () => {
 		const error = new Error('Error thrown by test');
 		netflixGetViewingHistory.rejects(error);
-		
+
 		try {
 			await getViewingHistory(netflix);
 		} catch (e) {
-		
+
 		} finally {
 			expect(consoleError).to.have.been.calledOnce;
 			expect(consoleError).to.have.been.calledWithExactly(error);
 		}
 	});
-	
+
 	it('Should throw an error when netflix.getViewingHistory throws an error', async () => {
 		netflixGetViewingHistory.rejects(new Error());
-		
+
 		await expect(getViewingHistory(netflix)).to.eventually.be.rejected;
 	});
 });
 
 describe('readDataFromChosenInput', () => {
 	let fsReadFileSync, processStdinRead, jsonParse;
-	
+
 	const ratings = [
 		{
 			'ratingType': 'star',
@@ -472,67 +472,67 @@ describe('readDataFromChosenInput', () => {
 		ratingHistory: ratings,
 		viewingHistory: views
 	};
-	
+
 	// JSON representations are hard coded into this test in order to notice when JSON.stringify changes
 	const ratingsJSON = '[{"ratingType":"star","title":"Some movie","movieID":12345678,"yourRating":5,"intRating":50,"date":"01/02/2016","timestamp":1234567890123,"comparableDate":1234567890},{"ratingType":"thumb","title":"Amazing Show","movieID":87654321,"yourRating":2,"date":"02/02/2018","timestamp":2234567890123,"comparableDate":2234567890}]';
 	const viewsJson = '[{"ratingType":"star","title":"Some movie","movieID":12345678,"yourRating":5,"intRating":50,"date":"01/02/2016","timestamp":1234567890123,"comparableDate":1234567890},{"ratingType":"thumb","title":"Amazing Show","movieID":87654321,"yourRating":2,"date":"02/02/2018","timestamp":2234567890123,"comparableDate":2234567890}]';
 	const totalHistoryJSON = '{"ratingHistory":' + ratingsJSON + ', "version":"' + versions.afterViewingHistory + '", "viewingHistory":' + viewsJson + '}';
 	const filename = 'test.json';
-	
+
 	beforeEach(() => {
 		processStdinRead = sinon.stub(process.stdin, 'read').returns(totalHistoryJSON);
 		fsReadFileSync = sinon.stub(fs, 'readFileSync').returns(totalHistoryJSON);
 		jsonParse = sinon.stub(JSON, 'parse').callThrough();
 	});
-	
+
 	afterEach(() => {
 		processStdinRead.restore();
 		fsReadFileSync.restore();
 		jsonParse.restore();
 	});
-	
+
 	it('Should read its data from stdin when no filename is specified', () => {
 		readDataFromChosenInput();
 		expect(processStdinRead).to.have.been.calledOnce;
 		expect(fsReadFileSync).to.not.have.been.called;
 	});
-	
+
 	it('Should read its data from a file when a filename is specified', () => {
 		readDataFromChosenInput(filename);
 		expect(fsReadFileSync).to.have.been.calledOnce;
 		expect(fsReadFileSync).to.have.been.calledWith(filename);
 		expect(processStdinRead).to.not.have.been.called;
 	});
-	
+
 	it('Should call JSON.parse to convert JSON from stdin to an object', () => {
 		readDataFromChosenInput();
 		expect(jsonParse).to.have.been.calledOnce;
 		expect(jsonParse).to.have.been.calledWithExactly(totalHistoryJSON);
 	});
-	
+
 	it('Should call JSON.parse to convert JSON from file to an object', () => {
 		readDataFromChosenInput(filename);
 		expect(jsonParse).to.have.been.calledOnce;
 		expect(jsonParse).to.have.been.calledWithExactly(totalHistoryJSON);
 	});
-	
+
 	it('Should always return an object with the properties ratingHistory and viewingHistory', () => {
 		const calledWithFilename = readDataFromChosenInput(filename);
 		const calledWithoutFilename = readDataFromChosenInput();
-		
+
 		for (let call of [calledWithFilename, calledWithoutFilename]) {
 			expect(call).to.be.instanceOf(Object);
 			expect(call).to.have.ownProperty('ratingHistory');
 			expect(call).to.have.ownProperty('viewingHistory');
 		}
 	});
-	
+
 	describe('When finding an array (data from v0.2.0 or lower)', () => {
 		beforeEach(() => {
 			processStdinRead.returns(ratingsJSON);
 			fsReadFileSync.returns(ratingsJSON);
 		});
-		
+
 		it('Should return a ratingHitory of data and a viewingHistory & version of null', () => {
 			const result = readDataFromChosenInput();
 			expect(result.ratingHistory).to.deep.equal(ratings);
@@ -540,7 +540,7 @@ describe('readDataFromChosenInput', () => {
 			expect(result.version).to.be.null;
 		});
 	});
-	
+
 	describe('When finding an object (data from v0.3.0 or higher)', () => {
 		it('Should return the correct version number, rating and viewing histories', () => {
 			const result = readDataFromChosenInput();
@@ -548,7 +548,7 @@ describe('readDataFromChosenInput', () => {
 			expect(result.ratingHistory).to.deep.equal(ratings);
 			expect(result.viewingHistory).to.deep.equal(views);
 		});
-		
+
 		const unacceptableScenarios = [
 			{
 				description: 'there is no rating history',
@@ -581,12 +581,12 @@ describe('readDataFromChosenInput', () => {
 				JSON: '1'
 			}
 		];
-		
+
 		for (const scenario of unacceptableScenarios) {
 			it('Should throw an error if ' + scenario.description, () => {
 				processStdinRead.returns(scenario.JSON);
 				fsReadFileSync.returns(scenario.JSON);
-				
+
 				expect(() => readDataFromChosenInput()).to.throw();
 			});
 		}
@@ -618,7 +618,7 @@ describe('setRatingHistory', () => {
 	];
 	const starRatings = ratings.filter(rating => rating.ratingType === 'star');
 	const thumbRatings = ratings.filter(rating => rating.ratingType === 'thumb');
-	
+
 	beforeEach(() => {
 		netflix = new Netflix();
 		netflixSetStarRating = sinon.stub(netflix, 'setStarRating')
@@ -627,80 +627,80 @@ describe('setRatingHistory', () => {
 			.resolves();
 		consoleError = sinon.stub(console, 'error');
 	});
-	
+
 	afterEach(() => {
 		netflixSetStarRating.restore();
 		netflixSetThumbRating.restore();
 		consoleError.restore();
 	});
-	
+
 	it('Should return a promise', () => {
 		expect(setRatingHistory(netflix)).to.be.instanceOf(Promise);
 	});
-	
+
 	it('Should take about 100ms per rating due to timeout between requests', async () => {
 		const beginning = Date.now().valueOf();
 		await setRatingHistory(netflix, ratings);
 		const end = Date.now().valueOf();
 		expect(end - beginning).to.not.be.lessThan(ratings.length * 100);
 	});
-	
+
 	it('Should call netflix.setStarRating once per star rating', async () => {
 		await setRatingHistory(netflix, ratings);
 		expect(netflixSetStarRating).to.have.callCount(starRatings.length);
-		
+
 		for (const rating of starRatings) {
 			expect(netflixSetStarRating).to.have.been.calledWithExactly(rating.movieID, rating.yourRating);
 		}
 	});
-	
+
 	it('Should call netflix.setThumbRating once per thumb rating', async () => {
 		await setRatingHistory(netflix, ratings);
 		expect(netflixSetThumbRating).to.have.callCount(thumbRatings.length);
-		
+
 		for (const rating of thumbRatings) {
 			expect(netflixSetThumbRating).to.have.been.calledWithExactly(rating.movieID, rating.yourRating);
 		}
 	});
-	
+
 	it('Should call main.waterfall once with an array of functions that return promises', async () => {
 		const waterfallStub = sinon.stub(main, 'waterfall').resolves();
-		
+
 		await setRatingHistory(netflix, ratings);
-		
+
 		expect(waterfallStub).to.have.been.calledOnce;
 		const functions = waterfallStub.args[0][0];
 		expect(functions).to.have.lengthOf(ratings.length);
-		
+
 		for (const func of functions) {
 			expect(func).to.be.instanceOf(Function);
 			expect(func()).to.be.instanceOf(Promise);
 		}
-		
+
 		waterfallStub.restore();
 	});
-	
+
 	it('Should call main.waterfall once with an array of functions', async () => {
 		const waterfallStub = sinon.stub(main, 'waterfall').resolves();
-		
+
 		await setRatingHistory(netflix, ratings);
-		
+
 		expect(waterfallStub).to.have.been.calledOnce;
 		const functions = waterfallStub.args[0][0];
-		
+
 		for (const func of functions) {
 			netflixSetStarRating.resolves();
 			netflixSetThumbRating.resolves();
 			await expect(func()).to.eventually.be.fulfilled;
-			
+
 			netflixSetStarRating.rejects(new Error());
 			netflixSetThumbRating.rejects(new Error());
 			await expect(func()).to.eventually.be.rejected;
 		}
-		
+
 		waterfallStub.restore();
 	});
-	
+
 	it('Should call netflix.setStarRating in correct order', async () => {
 		await setRatingHistory(netflix, ratings);
 		for (let i = 0; i < starRatings.length; i++) {
@@ -710,7 +710,7 @@ describe('setRatingHistory', () => {
 			);
 		}
 	});
-	
+
 	it('Should call netflix.setThumbRating in correct order', async () => {
 		await setRatingHistory(netflix, ratings);
 		for (let i = 0; i < thumbRatings.length; i++) {
@@ -753,112 +753,110 @@ describe('main', () => {
 		ratingHistory: ratings,
 		viewingHistory: views
 	};
-	
+
 	beforeEach(() => {
 		netflix = new Netflix();
 		args = {};
-		
+
 		netflixLogin = sinon.stub(netflix, 'login')
 			.resolves();
-		
+
 		mainExitWithMessage = sinon.stub(main, 'exitWithMessage');
-		
+
 		mainGetProfileGuid = sinon.stub(main, 'getProfileGuid')
 			.resolves(profile);
-		
+
 		mainSwitchProfile = sinon.stub(main, 'switchProfile')
 			.resolves();
-		
+
 		mainGetRatingHistory = sinon.stub(main, 'getRatingHistory')
 			.resolves(ratings);
-		
+
 		mainGetViewingHistory = sinon.stub(main, 'getViewingHistory')
 			.resolves(views);
-		
+
 		mainSetRatingHistory = sinon.stub(main, 'setRatingHistory')
 			.resolves();
-		
+
 		mainWriteToChosenOutput = sinon.stub(main, 'writeToChosenOutput');
-		
+
 		mainReadDataFromChosenInput = sinon.stub(main, 'readDataFromChosenInput')
 			.returns(data);
-		
+
 		stubs = [
 			netflixLogin, mainExitWithMessage, mainGetProfileGuid, mainSwitchProfile,
 			mainGetRatingHistory, mainGetViewingHistory, mainSetRatingHistory, mainWriteToChosenOutput,
 			mainReadDataFromChosenInput
 		];
 	});
-	
+
 	afterEach(() => {
 		stubs.forEach(stub => stub.restore());
 	});
-	
+
 	it('Should return a promise', () => {
 		expect(main(args, netflix)).to.be.instanceOf(Promise);
 	});
-	
-	it('Should call netflix.login with args.email and args.password', async () => {
-		args.email = {foo: 'bar'};
-		args.password = {bar: 'foo'};
-		
+
+	it('Should call netflix.login with args.cookie', async () => {
+		args.cookie = 'Some test string';
+
 		await main(args, netflix);
 		expect(netflixLogin).to.have.been.calledOnceWithExactly({
-																	email: args.email,
-																	password: args.password
-																})
+																	cookies: args.cookie
+																});
 	});
-	
+
 	it('Should call main.getProfileGuid after netflix.login', async () => {
 		await main(args, netflix);
 		expect(mainGetProfileGuid).to.have.been.calledAfter(netflixLogin);
 	});
-	
+
 	it('Should call main.getProfileGuid with args.profile', async () => {
 		args.profile = {foo: 'bar'};
-		
+
 		await main(args, netflix);
 		expect(mainGetProfileGuid).to.have.been.calledOnceWithExactly(netflix, args.profile);
 	});
-	
+
 	it('Should call main.switchProfile after main.getProfileGuid', async () => {
 		await main(args, netflix);
 		expect(mainSwitchProfile).to.have.been.calledAfter(mainGetProfileGuid);
 	});
-	
+
 	it('Should call main.switchProfile with the result of main.getProfileGuid', async () => {
 		await main(args, netflix);
 		expect(mainSwitchProfile).to.have.been.calledOnceWithExactly(netflix, profile);
 	});
-	
+
 	describe('Should call main.getRatingHistory', () => {
 		beforeEach(() => {
 			args.shouldExport = true;
 		});
-		
+
 		it('if args.shouldExport is true', async () => {
 			await main(args, netflix);
 			expect(mainGetRatingHistory).to.have.been.calledOnce;
 			expect(mainSetRatingHistory).to.not.have.been.called;
 		});
-		
+
 		it('after main.switchProfile', async () => {
 			await main(args, netflix);
 			expect(mainGetRatingHistory).to.have.been.calledAfter(mainSwitchProfile);
 		});
 	});
-	
+
 	describe('Should call main.getViewingHistory', () => {
 		beforeEach(() => {
 			args.shouldExport = true;
 		});
-		
+
 		it('if args.shouldExport is true', async () => {
 			await main(args, netflix);
 			expect(mainGetViewingHistory).to.have.been.calledOnce;
 			expect(mainSetRatingHistory).to.not.have.been.called;
 		});
-		
+
 		it('after main.getRatingHistory', async () => {
 			await main(args, netflix);
 			expect(mainGetViewingHistory).to.have.been.calledAfter(mainGetRatingHistory);
@@ -869,19 +867,19 @@ describe('main', () => {
 		beforeEach(() => {
 			args.shouldExport = true;
 		});
-		
+
 		it('with an undefined filename if args.export is true', async () => {
 			args.export = true;
 			await main(args, netflix);
 			expect(mainWriteToChosenOutput.getCall(0).args[1]).to.be.undefined;
 		});
-		
+
 		it('with filename provided in args.export', async () => {
 			args.export = {foo: 'bar'};
 			await main(args, netflix);
 			expect(mainWriteToChosenOutput.getCall(0).args[1]).to.equal(args.export);
 		});
-		
+
 		it('with args.spaces', async () => {
 			args.export = true;
 			args.spaces = {foo: 'bar'};
@@ -893,7 +891,7 @@ describe('main', () => {
 			await main(args, netflix);
 			expect(mainWriteToChosenOutput).to.have.been.calledAfter(mainGetViewingHistory);
 		});
-		
+
 		it('with an object containing a viewingHistory and a ratingHistory', async () => {
 			await main(args, netflix);
 			const firstCallArg = mainWriteToChosenOutput.getCall(0).args[0];
@@ -901,7 +899,7 @@ describe('main', () => {
 			expect(firstCallArg).to.haveOwnProperty('viewingHistory');
 			expect(firstCallArg).to.haveOwnProperty('ratingHistory');
 		});
-		
+
 		it('with an object containing the results of main.getRatingHistory and main.getViewingHistory', async () => {
 			await main(args, netflix);
 			const firstCallArg = mainWriteToChosenOutput.getCall(0).args[0];
@@ -910,59 +908,59 @@ describe('main', () => {
 			expect(firstCallArg.viewingHistory).to.deep.equal(views);
 		});
 	});
-	
+
 	describe('Should call main.readDataFromChosenInput', () => {
 		beforeEach(() => {
 			args.shouldExport = false;
 		});
-		
+
 		it('if args.shouldExport is false', async () => {
 			await main(args, netflix);
 			expect(mainReadDataFromChosenInput).to.have.been.calledOnce;
 		});
-		
+
 		it('with an undefined filename if args.import is true', async () => {
 			args.import = true;
 			await main(args, netflix);
 			expect(mainReadDataFromChosenInput).to.have.been.calledOnceWithExactly(undefined);
 		});
-		
+
 		it('with filename provided in args.import', async () => {
 			args.import = {foo: 'bar'};
 			await main(args, netflix);
 			expect(mainReadDataFromChosenInput).to.have.been.calledOnceWithExactly(args.import);
 		});
-		
+
 		it('after main.switchProfile', async () => {
 			await main(args, netflix);
 			expect(mainReadDataFromChosenInput).to.have.been.calledAfter(mainSwitchProfile);
 		});
 	});
-	
+
 	describe('Should call main.setRatingHistory', () => {
 		beforeEach(() => {
 			args.shouldExport = false;
 		});
-		
+
 		it('if args.shouldExport is false', async () => {
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledOnce;
 			expect(mainGetRatingHistory).to.not.have.been.called;
 		});
-		
+
 		it('with the rating history of the object returned by main.readDataFromChosenInput', async () => {
 			const obj = {version: 'bar', viewingHistory: 'cool movies', ratingHistory: 1234567890};
 			mainReadDataFromChosenInput.returns(obj);
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledOnceWithExactly(netflix, obj.ratingHistory);
 		});
-		
+
 		it('after main.readDataFromChosenInput', async () => {
 			await main(args, netflix);
 			expect(mainSetRatingHistory).to.have.been.calledAfter(mainReadDataFromChosenInput);
 		});
 	});
-	
+
 	describe('Should call main.exitWithMessage immediately when an error is thrown', () => {
 		it('by netflix.login', async () => {
 			const err = new Error();
@@ -970,7 +968,7 @@ describe('main', () => {
 			await main(args, netflix);
 			expect(mainExitWithMessage).to.have.been.calledOnceWithExactly(err);
 		});
-		
+
 		const functionsToTest = [
 			// @todo make this work with netflix
 			// {name: 'netflix.login', parent: netflix, args: {}},
@@ -982,22 +980,22 @@ describe('main', () => {
 			{name: 'main.readDataFromChosenInput', parent: main, args: {shouldExport: false}, type: 'function'},
 			{name: 'main.setRatingHistory', parent: main, args: {shouldExport: false}, type: 'promise'}
 		];
-		
+
 		for (let i = 0; i < functionsToTest.length; i++) {
 			let func = functionsToTest[i];
-			
+
 			it(`by ${func.name}`, async () => {
 				const err = new Error();
-				
+
 				const nameOfFunction = func.name.split('.')[1];
 				if (func.type === 'promise') {
 					func.parent[nameOfFunction].rejects(err);
 				} else {
 					func.parent[nameOfFunction].throws(err);
 				}
-				
+
 				await main(func.args, netflix);
-				
+
 				expect(mainExitWithMessage).to.have.been.calledOnce;
 				expect(mainExitWithMessage).to.have.been.calledOnceWithExactly(err);
 			});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1725,12 +1725,13 @@
       "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY="
     },
     "netflix2": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/netflix2/-/netflix2-1.0.1.tgz",
-      "integrity": "sha512-6dzW+gWJj+QWecCwpoUstbtxnvZoHk4QxbVCcwMZNazpxCDbILrvziBz2TPeRhFrNr7l6hgtBhDrjkO3B+QMVA==",
+      "version": "2.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/netflix2/-/netflix2-2.0.0-beta.1.tgz",
+      "integrity": "sha512-nIb9h1ORvhUVEiSOHZJe6aXZdkiRd2m6EAkT3GKO7CwDX+3ps0NMyWXPD+Iot2JQ+6bjUcDWSvfrDTRXhVdAiw==",
       "requires": {
         "cheerio": "^0.20.0",
         "extend": "^3.0.0",
+        "node-fetch": "^2.6.1",
         "request": "^2.72.0",
         "request-promise-native": "^1.0.7",
         "sprintf-js": "^1.0.3"
@@ -1783,6 +1784,11 @@
           "dev": true
         }
       }
+    },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
     },
     "nth-check": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netflix-migrate",
-  "version": "1.0.0",
+  "version": "2.0.0-beta.0",
   "description": "A command-line tool to migrate data to and from Netflix profiles",
   "keywords": [
     "netflix",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "array.prototype.find": "^2.0.0",
     "async": "^2.0.0-rc.5",
     "commander": "^2.9.0",
-    "netflix2": "^1.0.1",
+    "netflix2": "^2.0.0-beta.1",
     "prompt": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
As discussed in #37, Netflix seem to have added Google's reCAPTCHA to their login form, which prevents some users from using this CLI propperly. So, instead of authenticating via the login form, this PR authenticates its requests with the cookie set by Netflix when the user logs in. This requires the user to extract the cookie on their own. Instructions on how to do that can be found in the updated README.md.